### PR TITLE
fix language setting and scene management

### DIFF
--- a/.cocos-project.json
+++ b/.cocos-project.json
@@ -1,0 +1,3 @@
+{
+    "project_type": "cpp"
+}

--- a/Classes/Scenes/Settings.cpp
+++ b/Classes/Scenes/Settings.cpp
@@ -157,11 +157,11 @@ void Settings::displayLanguageMenu()
     
     // Back button
     auto back = Label::createWithSystemFont(LanguageManager::getLocalizedText("General", "back"), "", 40);
-    auto backButton = MenuItemLabel::create(back, CC_CALLBACK_1(Settings::buttonPressed, this));
-    backButton->setAnchorPoint(Point::ANCHOR_TOP_LEFT);
-    backButton->setTag(static_cast<int>(ButtonType::BACK_LANGUAGE));
-    backButton->setPosition(Point(10, origin.y + visibleSize.height - 10));
-    items.pushBack(backButton);
+    _backButton = MenuItemLabel::create(back, CC_CALLBACK_1(Settings::buttonPressed, this));
+    _backButton->setAnchorPoint(Point::ANCHOR_TOP_LEFT);
+    _backButton->setTag(static_cast<int>(ButtonType::BACK_LANGUAGE));
+    _backButton->setPosition(Point(10, origin.y + visibleSize.height - 10));
+    items.pushBack(_backButton);
     
     auto menu = Menu::createWithArray(items);
     menu->setPosition(Point::ZERO);

--- a/Classes/Singletons/SceneManager.cpp
+++ b/Classes/Singletons/SceneManager.cpp
@@ -40,8 +40,6 @@ SceneManager::~SceneManager()
 
 void SceneManager::runSceneWithType(const SceneType sceneType)
 {
-    SceneType oldScene = _currentSceneType;
-	_currentSceneType = sceneType;
 	Scene *sceneToRun = nullptr;
     switch (sceneType) {
         case SceneType::MAINMENU:
@@ -58,6 +56,8 @@ void SceneManager::runSceneWithType(const SceneType sceneType)
             return;
             break;
 	}
+    SceneType oldScene = _currentSceneType;
+    _currentSceneType = sceneType;
     sceneToRun->setTag(static_cast<int>(sceneType));
 
 	if (sceneToRun == nullptr) {

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This is not the final version and it has been only tested on iOS. In future comm
 
 Also, I will update this readme file to explain the different features.
 
+##Requirements
++ Cocos2d-x 3.3 Dec.12
++ Android NDK r10d
+
 ##Scenes
 
 ###Main Menu


### PR DESCRIPTION
Fix: Change language from settings.
Disable _currentSceneType update on SceneManager when trying to load not acceptable scene type.
Added missing file for android project.
